### PR TITLE
Die if Text::CSV cannot be instantiated

### DIFF
--- a/lib/Mojolicious/Plugin/ReplyTable.pm
+++ b/lib/Mojolicious/Plugin/ReplyTable.pm
@@ -38,7 +38,8 @@ sub _to_csv {
   require Text::CSV;
   my $csv_options = $c->stash('reply_table.csv_options') || {};
   $csv_options->{binary} = 1 unless exists $csv_options->{binary};
-  my $csv = Text::CSV->new($csv_options);
+  my $csv = Text::CSV->new($csv_options)
+    or die Text::CSV->error_diag();
   my $string = '';
   for my $row (@$data) {
     $csv->combine(@$row) || die $csv->error_diag;


### PR DESCRIPTION
Hi,

I have experienced a problem where incorrect options specified for `Text::CSV` resulted in a failure to instantiate an object and the `Can't call method "combine" on an undefined value` error.

It won't hurt to raise an exception with the proper message in such a case instead.